### PR TITLE
support_ipv6: Make both AF_INET and AF_INET6 as the valid ip for default gateway

### DIFF
--- a/system_configuration.cpp
+++ b/system_configuration.cpp
@@ -96,7 +96,7 @@ std::string SystemConfiguration::defaultGateway(std::string gateway)
         return gw;
     }
 
-    if (!isValidIP(AF_INET, gateway))
+    if (!isValidIP(AF_INET, gateway) && !isValidIP(AF_INET6, gateway))
     {
         log<level::ERR>("Not a valid Gateway",
                         entry("GATEWAY=%s", gateway.c_str()));


### PR DESCRIPTION
support_ipv6: Make both AF_INET and AF_INET6 as the valid ip for default gateway